### PR TITLE
Fix stm32mp157c-ev1 device tree OP-TEE device status

### DIFF
--- a/arch/arm/boot/dts/stm32mp157c-ev1.dts
+++ b/arch/arm/boot/dts/stm32mp157c-ev1.dts
@@ -372,3 +372,7 @@
 &usbphyc {
 	status = "okay";
 };
+
+&optee {
+	status = "okay";
+};


### PR DESCRIPTION
The optee device status is disabled by default, change its status to 'okay' in the DTS file of the stm32mp157c-ev1 board
Allow Linux to load the driver handling op-tee execution frame.

Signed-off-by: Timothée Cercueil <timothee.cercueil@st.com>